### PR TITLE
Fix: Correct broken "Edit this page" links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -40,7 +40,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/getdocsy/docs',
+            'https://github.com/getdocsy/docs/edit/main/',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
The "Edit this page" links in Docusaurus were pointing to an incorrect URL. This change updates the `editUrl` in `docusaurus.config.ts` to include `/edit/main/` in the path, ensuring the links point to the correct GitHub edit page.